### PR TITLE
Edit サンプルリストページをSPとPCでデザイン出し分け

### DIFF
--- a/components/molecules/lists/SampleList.vue
+++ b/components/molecules/lists/SampleList.vue
@@ -32,7 +32,24 @@
         </Modal>
       </template>
       <template v-else>
-        <p>pc</p>
+        <figure><img :src="sample.img" width="960" height="960"></figure>
+        <dl>
+          <dt>
+            <span>{{ sample.name }}</span><br>
+            {{ sample.nameJa }}
+          </dt>
+          <dd>
+            <p class="comment common-txt">
+              {{ sample.comment }}
+            </p>
+            <BtnText
+              btn-style="ghost"
+              color="white"
+              :link-path="sample.path"
+              :link-text="sample.name"
+            />
+          </dd>
+        </dl>
       </template>
     </li>
   </ul>
@@ -59,6 +76,7 @@ export default {
         {
           id: '1',
           path: 'hamburger-menu',
+          img: require('@/assets/img/sample/hamburger-menu.jpg'),
           name: 'Hamburger Menu',
           nameJa: 'ハンバーガーメニュー',
           comment: '言わずと知れた「三本線」のボタンクリックでメニューの開閉を実行。ヘッダ右上のボタンがそれ。（PC版では非表示）'
@@ -66,6 +84,7 @@ export default {
         {
           id: '2',
           path: 'modal-window',
+          img: require('@/assets/img/sample/modal-window.jpg'),
           name: 'Modal Window',
           nameJa: 'モーダルウィンドウ',
           comment: 'ウィンドウ内で、「子ウィンドウ」を展開。課題あり。どう解決するか。'
@@ -155,39 +174,59 @@ export default {
 
 @include lap() {
 .c-list_sample{
-  @include dflex(c, c);
+  @include dflex(c, fs);
   li{
-    width: 32%;
-    margin: 0 2% 1em 0;
-    &:nth-child(3n){
-      margin: 0 0 1em 0;
+    @include dflex(fs, fs);
+    flex-direction: column;
+    width: 280px;
+    margin: 0 40px 0 0;
+    &:nth-child(3n), &:last-child{
+      margin: 0;
     }
 
-    .c-modal_content{
-      @include dflex(c, c);
+    figure{
+      font-size: 0;
+      line-height: 0;
 
-      dl{
-        width: 50%;
+      img{
+        width: 85%;
+        height: 160px;
+        object-fit: cover;
+      }
+    }
+
+    dl{
+      width: 90%;
+      margin-left: auto;
+      padding: 5px 15px 15px;
+      background-color: rgba($dark, 0.7);
+      color: $white;
+      transform: translateY(-40px);
 
         dt{
           @include fontSet(18, 24, 100, $tab);
+          margin-bottom: 0.5em;
+          padding: 0 0.2em 0.5em;
+          border-bottom: 1px $white solid;
+          font-weight: 700;
 
           span{
-            @include fontSet(16, 24, 100, $tab);
+            @include fontSet(12, 12, 100, $tab);
+            font-weight: 400;
           }
         }
-        dd{
-          width: 90%;
-          margin: 0 auto;
 
+        dd{
+          .comment{
+            padding-bottom: 1em;
+          }
           .c-btn_text{
-            width: 70%;
+            width: 90%;
             margin: 0 auto;
           }
         }
       }
     }
   }
-}
 }
 </style>

--- a/components/templates/SampleList.vue
+++ b/components/templates/SampleList.vue
@@ -26,4 +26,10 @@ export default {
     @include ta(center);
   }
 }
+@include pc() {
+  #p-sample-list_box01{
+    width: per(1000, $pc);
+    margin: 0 auto;
+  }
+}
 </style>


### PR DESCRIPTION
### サンプルリストページをSPとPCでデザイン出し分け

- ウィンドウサイズ（1024px未満）でモーダルウィンドウを解除（ソースの出し分け）