### PR TITLE
Edit APIページをコンポネント読み込みに修正

### DIFF
--- a/components/atoms/buttons/TextBtn.vue
+++ b/components/atoms/buttons/TextBtn.vue
@@ -21,6 +21,13 @@
     </a>
   </p>
   <p
+    v-else-if="btnStyle === 'trash'"
+    class="c-btn_text"
+    :class="['c-btn_text--' + btnStyle, color]"
+  >
+    <span>{{ linkText }}<AtomsIconsTrashIcn /></span>
+  </p>
+  <p
     v-else
     class="c-btn_text"
     :class="['c-btn_text--' + btnStyle, color]"

--- a/components/atoms/icons/TrashIcn.vue
+++ b/components/atoms/icons/TrashIcn.vue
@@ -1,0 +1,15 @@
+<template>
+  <span><fa :icon="faTrashAlt" /></span>
+</template>
+
+<script>
+import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
+
+export default {
+  computed: {
+    faTrashAlt () {
+      return faTrashAlt
+    }
+  }
+}
+</script>

--- a/components/molecules/etc/ModalBook.vue
+++ b/components/molecules/etc/ModalBook.vue
@@ -49,6 +49,13 @@
         link-text="詳細を見る"
         class="c-booklist_btn"
       />
+      <AtomsButtonsTextBtn
+        btn-style="trash"
+        color="red"
+        link-text="本棚から削除する"
+        class="c-booklist_btn--trash"
+        @click.native="deleteBook"
+      />
     </MoleculesEtcModal>
   </div>
 </template>
@@ -119,6 +126,9 @@ export default {
     },
     closeModal () {
       this.modalFlag = false
+    },
+    deleteBook () {
+      this.$emit('delete-btn')
     }
   }
 }

--- a/components/molecules/etc/ModalBook.vue
+++ b/components/molecules/etc/ModalBook.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="c-booklist_wrap">
+    <figure class="c-booklist_thumb" @click="openModal">
+      <img :src="bookImg">
+    </figure>
+    <MoleculesEtcModal
+      v-if="modalFlag"
+      :top-position="saveScroll"
+      @close-modal="closeModal"
+    >
+      <figure class="c-booklist_thumb--modal">
+        <a :href="bookLink" target="_blank">
+          <img :src="bookImg">
+        </a>
+      </figure>
+      <dl class="c-booklist_data">
+        <dt class="c-booklist_data--title">
+          {{ bookTitle }}
+        </dt>
+        <dd>
+          <ul>
+            <li>
+              <dl>
+                <dt>作者</dt>
+                <dd>
+                  <p v-for="(bookAuthor, index) in bookAuthors" :key="index">
+                    {{ bookAuthor }}
+                  </p>
+                </dd>
+              </dl>
+            </li>
+            <li>
+              <dl>
+                <dt>出版社</dt>
+                <dd>{{ bookPublisher }}</dd>
+              </dl>
+            </li>
+          </ul>
+        </dd>
+      </dl>
+      <dl v-if="bookComment !== ''" class="c-booklist_comment">
+        <dt>■コメント</dt>
+        <dd>{{ bookComment }}</dd>
+      </dl>
+      <AtomsButtonsTextBtn
+        btn-style="outside"
+        color="dark"
+        :link-path="bookLink"
+        link-text="詳細を見る"
+        class="c-booklist_btn"
+      />
+    </MoleculesEtcModal>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    bookImg: {
+      type: String,
+      default: ''
+    },
+    bookLink: {
+      type: String,
+      default: ''
+    },
+    bookTitle: {
+      type: String,
+      default: ''
+    },
+    bookAuthors: {
+      type: Array,
+      default: () => []
+    },
+    bookPublisher: {
+      type: String,
+      default: ''
+    },
+    bookComment: {
+      type: String,
+      default: ''
+    }
+  },
+  data () {
+    return {
+      modalFlag: false,
+      modalItem: '',
+      scrollY: 0,
+      saveScroll: ''
+    }
+  },
+  head () {
+    return {
+      bodyAttrs: {
+        class: this.isModalOpen ? 'modal-on' : ''
+      }
+    }
+  },
+  computed: {
+    isModalOpen () {
+      return this.modalFlag
+    }
+  },
+  mounted () {
+    window.addEventListener('scroll', this.getScrollY)
+  },
+  beforeDestroy () {
+    window.removeEventListener('scroll', this.getScrollY)
+  },
+  methods: {
+    getScrollY () {
+      this.scrollY = window.scrollY
+    },
+    openModal () {
+      this.modalFlag = true
+      // this.modalItem = book
+      this.getScrollY()
+      this.saveScroll = this.scrollY
+    },
+    closeModal () {
+      this.modalFlag = false
+    }
+  }
+}
+</script>

--- a/components/molecules/etc/SearchIsbn.vue
+++ b/components/molecules/etc/SearchIsbn.vue
@@ -1,0 +1,24 @@
+<template>
+  <input type="text" placeholder="ISBN10 or ISBN13" v-model="inputIsbn">
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: String,
+      default: ''
+    }
+  },
+  computed: {
+    inputIsbn: {
+      get() {
+        return this.value;
+      },
+      set(newValue) {
+        this.$emit("input", newValue);
+      },
+    },
+  }
+}
+</script>

--- a/components/molecules/etc/SearchIsbn.vue
+++ b/components/molecules/etc/SearchIsbn.vue
@@ -1,5 +1,5 @@
 <template>
-  <input type="text" placeholder="ISBN10 or ISBN13" v-model="inputIsbn">
+  <input v-model="inputIsbn" type="text" placeholder="ISBN10 or ISBN13">
 </template>
 
 <script>
@@ -12,13 +12,13 @@ export default {
   },
   computed: {
     inputIsbn: {
-      get() {
-        return this.value;
+      get () {
+        return this.value
       },
-      set(newValue) {
-        this.$emit("input", newValue);
-      },
-    },
+      set (newValue) {
+        this.$emit('input', newValue)
+      }
+    }
   }
 }
 </script>

--- a/components/molecules/etc/SearchIsbnResult.vue
+++ b/components/molecules/etc/SearchIsbnResult.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="c-bookinfo">
+    <figure class="c-bookinfo_thumb">
+      <a :href="itemLink" target="_blank">
+        <img :src="itemImg">
+      </a>
+    </figure>
+    <dl class="c-bookinfo_data">
+      <dt class="c-bookinfo_data--title">
+        {{ itemTitle }}
+      </dt>
+      <dd class="c-bookinfo_data--detail">
+        <ul>
+          <li>
+            <dl>
+              <dt>作者</dt>
+              <dd>
+                <p v-for="(author, index) in itemAuthors" :key="index">
+                  {{ author }}
+                </p>
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <dl>
+              <dt>出版社</dt>
+              <dd>{{ itemPublisher }}</dd>
+            </dl>
+          </li>
+        </ul>
+      </dd>
+    </dl>
+    <p class="c-bookinfo_data--intro">
+      {{ itemDescription }}
+    </p>
+    <AtomsButtonsTextBtn
+      btn-style="outside"
+      color="dark"
+      :link-path="itemLink"
+      link-text="詳細を見る"
+      class="c-bookinfo_data--btn"
+    />
+    <dl class="c-bookinfo_comment">
+      <dt>■コメント</dt>
+      <dd>
+        <textarea
+          v-model="inputItemComment"
+        />
+      </dd>
+    </dl>
+    <p class="c-bookinfo_save" @click="saveBtn">
+      <span>保存する<fa :icon="faStickyNote" /></span>
+    </p>
+  </div>
+</template>
+
+<script>
+import { faStickyNote } from '@fortawesome/free-solid-svg-icons'
+
+export default {
+  props: {
+    itemLink: {
+      type: String,
+      default: ''
+    },
+    itemImg: {
+      type: String,
+      default: ''
+    },
+    itemTitle: {
+      type: String,
+      default: ''
+    },
+    itemAuthors: {
+      type: Array,
+      default: () => []
+    },
+    itemPublisher: {
+      type: String,
+      default: ''
+    },
+    itemDescription: {
+      type: String,
+      default: ''
+    },
+    itemComment: {
+      type: String,
+      default: ''
+    }
+  },
+  computed: {
+    faStickyNote () {
+      return faStickyNote
+    },
+    inputItemComment: {
+      get () {
+        return this.itemComment
+      },
+      set (newValue) {
+        this.$emit('input', newValue)
+      }
+    }
+  },
+  methods: {
+    saveBtn () {
+      this.$emit('saveBtn')
+    }
+  }
+}
+</script>

--- a/components/templates/Api.vue
+++ b/components/templates/Api.vue
@@ -31,7 +31,18 @@
           </p>
         </template>
         <div v-for="item in items" :key="item.id" class="p-api_box02--result">
-          <div class="c-bookinfo">
+          <MoleculesEtcSearchIsbnResult
+            v-model="itemComment"
+            :item-link="itemLink"
+            :item-img="itemImg"
+            :item-title="itemTitle"
+            :item-authors="itemAuthors"
+            :item-publisher="itemPublisher"
+            :item-description="item.volumeInfo.description"
+            :item-comment="itemComment"
+            @saveBtn="saveBtn"
+          />
+          <!-- <div class="c-bookinfo">
             <figure class="c-bookinfo_thumb">
               <a :href="itemLink" target="_blank">
                 <img :src="itemImg">
@@ -83,7 +94,7 @@
             <p class="c-bookinfo_save" @click="saveBtn">
               <span>保存する<fa :icon="faStickyNote" /></span>
             </p>
-          </div>
+          </div> -->
         </div>
       </div>
     </section><!-- /box02 -->

--- a/components/templates/Api.vue
+++ b/components/templates/Api.vue
@@ -54,7 +54,7 @@
           tit-txt="Your Favorite Books"
         />
         <ul class="c-booklist">
-          <li v-for="(book, index) in reverseBooks" :key="book.id">
+          <li v-for="(book, index) in books" :key="book.id">
             <MoleculesEtcModalBook
               :book-img="book.img"
               :book-link="book.link"
@@ -63,7 +63,6 @@
               :book-publisher="book.publisher"
               :book-comment="book.comment"
               @delete-btn="deleteBtn(index)"
-              @click.native="countIndex(index)"
             />
           </li>
         </ul>
@@ -105,9 +104,6 @@ export default {
   computed: {
     faStickyNote () {
       return faStickyNote
-    },
-    reverseBooks () {
-      return this.books.slice().reverse()
     }
   },
   watch: {
@@ -155,7 +151,7 @@ export default {
         publisher: this.itemPublisher,
         comment: this.itemComment
       }
-      this.books.push(saveGroup)
+      this.books.unshift(saveGroup)
       saveGroup = ''
       this.isbn = ''
       this.items = ''
@@ -171,9 +167,6 @@ export default {
       this.books.splice(x, 1)
       this.saveBook()
       console.log(x)
-    },
-    countIndex (hoge) {
-      console.log(hoge)
     }
   }
 }

--- a/components/templates/Api.vue
+++ b/components/templates/Api.vue
@@ -22,7 +22,8 @@
         />
         <dl class="p-api_box02--search">
           <dt>ISBN検索</dt>
-          <dd><input v-model="isbn" type="text" placeholder="ISBN10 or ISBN13"></dd>
+          <dd><MoleculesEtcSearchIsbn v-model="isbn" /></dd>
+          <!-- <dd><input v-model="isbn" type="text" placeholder="ISBN10 or ISBN13"></dd> -->
         </dl>
         <template v-if="message">
           <p class="p-api_box02--message">

--- a/components/templates/Api.vue
+++ b/components/templates/Api.vue
@@ -42,59 +42,6 @@
             :item-comment="itemComment"
             @saveBtn="saveBtn"
           />
-          <!-- <div class="c-bookinfo">
-            <figure class="c-bookinfo_thumb">
-              <a :href="itemLink" target="_blank">
-                <img :src="itemImg">
-              </a>
-            </figure>
-            <dl class="c-bookinfo_data">
-              <dt class="c-bookinfo_data--title">
-                {{ itemTitle }}
-              </dt>
-              <dd class="c-bookinfo_data--detail">
-                <ul>
-                  <li>
-                    <dl>
-                      <dt>作者</dt>
-                      <dd>
-                        <p v-for="(author, index) in itemAuthors" :key="index">
-                          {{ author }}
-                        </p>
-                      </dd>
-                    </dl>
-                  </li>
-                  <li>
-                    <dl>
-                      <dt>出版社</dt>
-                      <dd>{{ itemPublisher }}</dd>
-                    </dl>
-                  </li>
-                </ul>
-              </dd>
-            </dl>
-            <p class="c-bookinfo_data--intro">
-              {{ item.volumeInfo.description }}
-            </p>
-            <AtomsButtonsTextBtn
-              btn-style="outside"
-              color="dark"
-              :link-path="item.volumeInfo.previewLink"
-              link-text="詳細を見る"
-              class="c-bookinfo_data--btn"
-            />
-            <dl class="c-bookinfo_comment">
-              <dt>■コメント</dt>
-              <dd>
-                <textarea
-                  v-model="itemComment"
-                />
-              </dd>
-            </dl>
-            <p class="c-bookinfo_save" @click="saveBtn">
-              <span>保存する<fa :icon="faStickyNote" /></span>
-            </p>
-          </div> -->
         </div>
       </div>
     </section><!-- /box02 -->
@@ -108,56 +55,14 @@
         />
         <ul class="c-booklist">
           <li v-for="book in reverseBooks" :key="book.id">
-            <figure class="c-booklist_thumb" @click="openModal(book)">
-              <img :src="book.img">
-            </figure>
-            <MoleculesEtcModal
-              v-if="modalFlag"
-              :top-position="saveScroll"
-              @close-modal="closeModal"
-            >
-              <figure class="c-booklist_thumb--modal">
-                <a :href="modalItem.link" target="_blank">
-                  <img :src="modalItem.img">
-                </a>
-              </figure>
-              <dl class="c-booklist_data">
-                <dt class="c-booklist_data--title">
-                  {{ modalItem.title }}
-                </dt>
-                <dd>
-                  <ul>
-                    <li>
-                      <dl>
-                        <dt>作者</dt>
-                        <dd>
-                          <p v-for="(bookAuthor, index) in modalItem.authors" :key="index">
-                            {{ bookAuthor }}
-                          </p>
-                        </dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <dl>
-                        <dt>出版社</dt>
-                        <dd>{{ modalItem.publisher }}</dd>
-                      </dl>
-                    </li>
-                  </ul>
-                </dd>
-              </dl>
-              <dl v-if="modalItem.comment !== ''" class="c-booklist_comment">
-                <dt>■コメント</dt>
-                <dd>{{ modalItem.comment }}</dd>
-              </dl>
-              <AtomsButtonsTextBtn
-                btn-style="outside"
-                color="dark"
-                :link-path="modalItem.link"
-                link-text="詳細を見る"
-                class="c-booklist_btn"
-              />
-            </MoleculesEtcModal>
+            <MoleculesEtcModalBook
+              :book-img="book.img"
+              :book-link="book.link"
+              :book-title="book.title"
+              :book-authors="book.authors"
+              :book-publisher="book.publisher"
+              :book-comment="book.comment"
+            />
           </li>
         </ul>
       </div>
@@ -192,17 +97,7 @@ export default {
       itemAuthors: [],
       itemPublisher: '',
       haveBooks: false,
-      modalFlag: false,
-      modalItem: '',
-      scrollY: 0,
-      saveScroll: ''
-    }
-  },
-  head () {
-    return {
-      bodyAttrs: {
-        class: this.isModalOpen ? 'modal-on' : ''
-      }
+      modalItem: ''
     }
   },
   computed: {
@@ -211,9 +106,6 @@ export default {
     },
     reverseBooks () {
       return this.books.slice().reverse()
-    },
-    isModalOpen () {
-      return this.modalFlag
     }
   },
   watch: {
@@ -232,18 +124,11 @@ export default {
         this.haveBooks = false
       }
     }
-    window.addEventListener('scroll', this.getScrollY)
-  },
-  beforeDestroy () {
-    window.removeEventListener('scroll', this.getScrollY)
   },
   created () {
     this.debouncedGetAnswer = _.debounce(this.getAnswer, 1000)
   },
   methods: {
-    getScrollY () {
-      this.scrollY = window.scrollY
-    },
     getAnswer () {
       if (this.isbn) {
         axios.get('https://www.googleapis.com/books/v1/volumes?q=isbn:' + this.isbn).then((response) => {
@@ -279,15 +164,6 @@ export default {
     saveBook () {
       const parsed = JSON.stringify(this.books)
       localStorage.setItem('books', parsed)
-    },
-    openModal (book) {
-      this.modalFlag = true
-      this.modalItem = book
-      this.getScrollY()
-      this.saveScroll = this.scrollY
-    },
-    closeModal () {
-      this.modalFlag = false
     }
   }
 }

--- a/components/templates/Api.vue
+++ b/components/templates/Api.vue
@@ -54,7 +54,7 @@
           tit-txt="Your Favorite Books"
         />
         <ul class="c-booklist">
-          <li v-for="book in reverseBooks" :key="book.id">
+          <li v-for="(book, index) in reverseBooks" :key="book.id">
             <MoleculesEtcModalBook
               :book-img="book.img"
               :book-link="book.link"
@@ -62,6 +62,8 @@
               :book-authors="book.authors"
               :book-publisher="book.publisher"
               :book-comment="book.comment"
+              @delete-btn="deleteBtn(index)"
+              @click.native="countIndex(index)"
             />
           </li>
         </ul>
@@ -164,6 +166,14 @@ export default {
     saveBook () {
       const parsed = JSON.stringify(this.books)
       localStorage.setItem('books', parsed)
+    },
+    deleteBtn (x) {
+      this.books.splice(x, 1)
+      this.saveBook()
+      console.log(x)
+    },
+    countIndex (hoge) {
+      console.log(hoge)
     }
   }
 }


### PR DESCRIPTION
### APIページをコンポネント読み込みに修正

- ISBN検索窓や結果表示箇所を子コンポネントにして読み込み
- 一度保存した配列を削除するボタンを実装