### PR TITLE
Edit モーダルウィンドウをstoreのjsファイルから読み込み

### DIFF
--- a/assets/js/SampleList.js
+++ b/assets/js/SampleList.js
@@ -1,21 +1,36 @@
-function samples () {
-  const sampleList = [
-    {
-      id: 1,
-      hash: 'hamburger-menu',
-      name: 'Hamburger Menu',
-      nameJa: 'ハンバーガーメニュー'
-    },
-    {
-      id: 2,
-      hash: 'modal-window',
-      name: 'Modal Window',
-      nameJa: 'モーダルウィンドウ'
-    }
-  ]
-  return sampleList
-}
+const sampleList = [
+  {
+    id: '1',
+    path: 'hamburger-menu',
+    img: '/images/sample/hamburger-menu.jpg',
+    name: 'Hamburger Menu',
+    nameJa: 'ハンバーガーメニュー',
+    comment: '言わずと知れた「三本線」のボタンクリックでメニューの開閉を実行。ヘッダ右上のボタンがそれ。（PC版では非表示）'
+  },
+  {
+    id: '2',
+    path: 'modal-window',
+    img: '/images/sample/modal-window.jpg',
+    name: 'Modal Window',
+    nameJa: 'モーダルウィンドウ',
+    comment: 'ウィンドウ内で、「子ウィンドウ」を展開。課題あり。どう解決するか。'
+  },
+  {
+    id: '3',
+    path: 'accordion',
+    img: '/images/sample/accordion.jpg',
+    name: 'Accordion',
+    nameJa: 'アコーディオン',
+    comment: 'ボタンクリックで下に展開するアコーディオンメニュー（トグルメニュー）。ベタ書きと配列処理の2パタン'
+  },
+  {
+    id: '4',
+    path: 'tabs-menu',
+    img: '/images/sample/tabs-menu.jpg',
+    name: 'Tabs Menu',
+    nameJa: 'タブメニュー',
+    comment: 'タブ切り替え機能。PC・スマホともにタブメニューと、PCではタブ、スマホではアコーディオンの2パタン。どちらも配列処理'
+  }
+]
 
-export default {
-  samples
-}
+export default sampleList

--- a/components/molecules/etc/ModalBook.vue
+++ b/components/molecules/etc/ModalBook.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="c-booklist_wrap">
-    <figure class="c-booklist_thumb" @click="openModal">
+    <figure class="c-booklist_thumb" @click="$store.commit('Modal/openModal')">
       <img :src="bookImg">
     </figure>
     <MoleculesEtcModal
       v-if="isModalState"
-      :top-position="saveScroll"
-      @close-modal="closeModal"
+      :top-position="$window.pageYOffset"
+      @close-modal="$store.commit('Modal/closeModal')"
     >
       <figure class="c-booklist_thumb--modal">
         <a :href="bookLink" target="_blank">
@@ -63,6 +63,10 @@
 <script>
 export default {
   props: {
+    bookArray: {
+      type: Array,
+      default: () => []
+    },
     bookImg: {
       type: String,
       default: ''
@@ -108,24 +112,7 @@ export default {
       return this.$store.state.Modal.modalFlag
     }
   },
-  mounted () {
-    window.addEventListener('scroll', this.getScrollY)
-  },
-  beforeDestroy () {
-    window.removeEventListener('scroll', this.getScrollY)
-  },
   methods: {
-    getScrollY () {
-      this.scrollY = window.scrollY
-    },
-    openModal () {
-      this.$store.commit('Modal/openModal')
-      this.getScrollY()
-      this.saveScroll = this.scrollY
-    },
-    closeModal () {
-      this.$store.commit('Modal/closeModal')
-    },
     deleteBook () {
       this.$emit('delete-btn')
     }

--- a/components/molecules/etc/ModalBook.vue
+++ b/components/molecules/etc/ModalBook.vue
@@ -4,7 +4,7 @@
       <img :src="bookImg">
     </figure>
     <MoleculesEtcModal
-      v-if="modalFlag"
+      v-if="isModalState"
       :top-position="saveScroll"
       @close-modal="closeModal"
     >
@@ -90,7 +90,7 @@ export default {
   },
   data () {
     return {
-      modalFlag: false,
+      modalFlag: '',
       modalItem: '',
       scrollY: 0,
       saveScroll: ''
@@ -99,13 +99,13 @@ export default {
   head () {
     return {
       bodyAttrs: {
-        class: this.isModalOpen ? 'modal-on' : ''
+        class: this.isModalState ? 'modal-on' : ''
       }
     }
   },
   computed: {
-    isModalOpen () {
-      return this.modalFlag
+    isModalState () {
+      return this.$store.state.Modal.modalFlag
     }
   },
   mounted () {
@@ -119,13 +119,12 @@ export default {
       this.scrollY = window.scrollY
     },
     openModal () {
-      this.modalFlag = true
-      // this.modalItem = book
+      this.$store.commit('Modal/openModal')
       this.getScrollY()
       this.saveScroll = this.scrollY
     },
     closeModal () {
-      this.modalFlag = false
+      this.$store.commit('Modal/closeModal')
     },
     deleteBook () {
       this.$emit('delete-btn')

--- a/components/molecules/etc/ModalBook.vue
+++ b/components/molecules/etc/ModalBook.vue
@@ -63,9 +63,17 @@
 <script>
 export default {
   props: {
-    bookArray: {
-      type: Array,
-      default: () => []
+    bookIndex: {
+      type: Number,
+      default: 0
+    },
+    bookId: {
+      type: String,
+      default: ''
+    },
+    bookFlag: {
+      type: Boolean,
+      default: false
     },
     bookImg: {
       type: String,

--- a/components/molecules/etc/ModalBook.vue
+++ b/components/molecules/etc/ModalBook.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="c-booklist_wrap">
-    <figure class="c-booklist_thumb" @click="$store.commit('Modal/openModal')">
+    <figure class="c-booklist_thumb" @click="openModal">
       <img :src="bookImg">
     </figure>
     <MoleculesEtcModal
@@ -10,7 +10,7 @@
     >
       <figure class="c-booklist_thumb--modal">
         <a :href="bookLink" target="_blank">
-          <img :src="bookImg">
+          <img :src="bookImgModal">
         </a>
       </figure>
       <dl class="c-booklist_data">
@@ -63,24 +63,16 @@
 <script>
 export default {
   props: {
-    bookIndex: {
-      type: Number,
-      default: 0
-    },
-    bookId: {
-      type: String,
-      default: ''
-    },
-    bookFlag: {
-      type: Boolean,
-      default: false
-    },
     bookImg: {
       type: String,
       default: ''
     },
-    bookLink: {
+    bookImgModal: {
       type: String,
+      default: ''
+    },
+    bookLink: {
+      type: null,
       default: ''
     },
     bookTitle: {
@@ -113,6 +105,9 @@ export default {
     }
   },
   methods: {
+    openModal () {
+      this.$emit('open-modal')
+    },
     deleteBook () {
       this.$emit('delete-btn')
     }

--- a/components/molecules/etc/ModalBook.vue
+++ b/components/molecules/etc/ModalBook.vue
@@ -92,14 +92,6 @@ export default {
       default: ''
     }
   },
-  data () {
-    return {
-      modalFlag: '',
-      modalItem: '',
-      scrollY: 0,
-      saveScroll: ''
-    }
-  },
   head () {
     return {
       bodyAttrs: {

--- a/components/molecules/lists/SampleList.vue
+++ b/components/molecules/lists/SampleList.vue
@@ -1,31 +1,31 @@
 <template>
   <ul class="c-list_sample">
-    <li v-for="sample in limitCount" :key="sample.id" class="c-modal" :class="postItem.path">
+    <li v-for="(sample, index) in limitCount" :key="sample.id" class="c-modal" :class="modalItem.path">
       <template v-if="$window.width < 1024">
         <AtomsButtonsTextBtn
           btn-style="modal"
           :link-text="sample.name"
           color="white"
-          @open-modal="openModal(sample)"
+          @open-modal="openModal(sample, index)"
         />
         <MoleculesEtcModal
-          v-if="modalFlag"
-          @close-modal="closeModal"
+          v-if="isModalState"
+          @close-modal="$store.commit('Modal/closeModal')"
         >
           <dl>
             <dt>
-              <span>{{ postItem.name }}</span><br>
-              {{ postItem.nameJa }}
+              <span>{{ modalItem.name }}</span><br>
+              {{ modalItem.nameJa }}
             </dt>
             <dd>
               <p class="comment f-txt">
-                {{ postItem.comment }}
+                {{ modalItem.comment }}
               </p>
               <AtomsButtonsTextBtn
                 btn-style="ghost"
                 color="white"
-                :link-path="postItem.path"
-                :link-text="postItem.name"
+                :link-path="modalItem.path"
+                :link-text="modalItem.name"
               />
             </dd>
           </dl>
@@ -61,8 +61,7 @@ import sampleList from 'assets/js/SampleList'
 export default {
   data () {
     return {
-      modalFlag: false,
-      postItem: ''
+      modalItem: ''
     }
   },
   computed: {
@@ -72,15 +71,16 @@ export default {
       } else {
         return sampleList
       }
+    },
+    isModalState () {
+      return this.$store.state.Modal.modalFlag
     }
   },
   methods: {
-    openModal (sample) {
-      this.modalFlag = true
-      this.postItem = sample
-    },
-    closeModal () {
-      this.modalFlag = false
+    openModal (sample, index) {
+      this.$store.commit('Modal/openModal')
+      this.modalItem = sample
+      this.countArray = index
     }
   }
 }

--- a/components/molecules/lists/SampleList.vue
+++ b/components/molecules/lists/SampleList.vue
@@ -56,6 +56,8 @@
 </template>
 
 <script>
+import sampleList from 'assets/js/SampleList'
+
 export default {
   data () {
     return {
@@ -66,47 +68,10 @@ export default {
   computed: {
     limitCount () {
       if (this.$route.name === 'index') {
-        return this.samples.slice(0, 3)
+        return sampleList.slice(0, 3)
       } else {
-        return this.samples
+        return sampleList
       }
-    },
-    samples () {
-      const sampleList = [
-        {
-          id: '1',
-          path: 'hamburger-menu',
-          img: '/images/sample/hamburger-menu.jpg',
-          name: 'Hamburger Menu',
-          nameJa: 'ハンバーガーメニュー',
-          comment: '言わずと知れた「三本線」のボタンクリックでメニューの開閉を実行。ヘッダ右上のボタンがそれ。（PC版では非表示）'
-        },
-        {
-          id: '2',
-          path: 'modal-window',
-          img: '/images/sample/modal-window.jpg',
-          name: 'Modal Window',
-          nameJa: 'モーダルウィンドウ',
-          comment: 'ウィンドウ内で、「子ウィンドウ」を展開。課題あり。どう解決するか。'
-        },
-        {
-          id: '3',
-          path: 'accordion',
-          img: '/images/sample/accordion.jpg',
-          name: 'Accordion',
-          nameJa: 'アコーディオン',
-          comment: 'ボタンクリックで下に展開するアコーディオンメニュー（トグルメニュー）。ベタ書きと配列処理の2パタン'
-        },
-        {
-          id: '4',
-          path: 'tabs-menu',
-          img: '/images/sample/tabs-menu.jpg',
-          name: 'Tabs Menu',
-          nameJa: 'タブメニュー',
-          comment: 'タブ切り替え機能。PC・スマホともにタブメニューと、PCではタブ、スマホではアコーディオンの2パタン。どちらも配列処理'
-        }
-      ]
-      return sampleList
     }
   },
   methods: {

--- a/components/templates/Api.vue
+++ b/components/templates/Api.vue
@@ -97,8 +97,7 @@ export default {
       itemImg: '',
       itemAuthors: [],
       itemPublisher: '',
-      haveBooks: false,
-      modalItem: ''
+      haveBooks: false
     }
   },
   computed: {

--- a/components/templates/Api.vue
+++ b/components/templates/Api.vue
@@ -166,7 +166,6 @@ export default {
     deleteBtn (x) {
       this.books.splice(x, 1)
       this.saveBook()
-      console.log(x)
     }
   }
 }

--- a/components/templates/Api.vue
+++ b/components/templates/Api.vue
@@ -57,12 +57,14 @@
           <li v-for="(book, index) in books" :key="book.id">
             <MoleculesEtcModalBook
               :book-img="book.img"
-              :book-link="book.link"
-              :book-title="book.title"
-              :book-authors="book.authors"
-              :book-publisher="book.publisher"
-              :book-comment="book.comment"
-              @delete-btn="deleteBtn(index)"
+              :book-img-modal="modalItem.img"
+              :book-link="modalItem.link"
+              :book-title="modalItem.title"
+              :book-authors="modalItem.authors"
+              :book-publisher="modalItem.publisher"
+              :book-comment="modalItem.comment"
+              @open-modal="openModal(book, index)"
+              @delete-btn="deleteBtn()"
             />
           </li>
         </ul>
@@ -93,11 +95,13 @@ export default {
       itemComment: '',
       itemId: '',
       itemTitle: '',
-      itemLink: '',
+      itemLink: [],
       itemImg: '',
       itemAuthors: [],
       itemPublisher: '',
-      haveBooks: false
+      haveBooks: false,
+      modalItem: '',
+      countArray: ''
     }
   },
   computed: {
@@ -148,7 +152,8 @@ export default {
         img: this.itemImg,
         authors: this.itemAuthors,
         publisher: this.itemPublisher,
-        comment: this.itemComment
+        comment: this.itemComment,
+        flag: false
       }
       this.books.unshift(saveGroup)
       saveGroup = ''
@@ -162,9 +167,15 @@ export default {
       const parsed = JSON.stringify(this.books)
       localStorage.setItem('books', parsed)
     },
-    deleteBtn (x) {
-      this.books.splice(x, 1)
+    openModal (book, index) {
+      this.$store.commit('Modal/openModal')
+      this.modalItem = book
+      this.countArray = index
+    },
+    deleteBtn () {
+      this.books.splice(this.countArray, 1)
       this.saveBook()
+      this.$store.commit('Modal/closeModal')
     }
   }
 }

--- a/store/Modal.js
+++ b/store/Modal.js
@@ -1,18 +1,11 @@
 export const state = () => ({
-  isModalFlag: false
+  modalFlag: false
 })
-
 export const mutations = {
-  setModalFlag (state, isModalFlag) {
-    state.isModalFlag = isModalFlag
-  }
-}
-
-export const actions = {
-  openModal ({ commit }) {
-    commit('setModalFlag', true)
+  openModal (state) {
+    state.modalFlag = true
   },
-  closeModal ({ commit }) {
-    commit('setModalFlag', false)
+  closeModal (state) {
+    state.modalFlag = false
   }
 }


### PR DESCRIPTION
### モーダルウィンドウをstoreのjsファイルから読み込み

- store/Modal.jsの修正
- assets/js/SampleList.jsの追加
- APIページの削除ボタンの仕組みを変更
- SampleListページの配列を外部読み込みに変更